### PR TITLE
Added torch.cuda.empty_cache()

### DIFF
--- a/awq/entry.py
+++ b/awq/entry.py
@@ -73,9 +73,9 @@ def build_model_and_enc(model_path):
     # all hf model
     config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
     if "mpt" in config.__class__.__name__.lower():
-        enc = AutoTokenizer.from_pretrained(config.tokenizer_name)
+        enc = AutoTokenizer.from_pretrained(config.tokenizer_name, trust_remote_code=True)
     else:
-        enc = AutoTokenizer.from_pretrained(model_path, use_fast=False)
+        enc = AutoTokenizer.from_pretrained(model_path, use_fast=False, trust_remote_code=True)
 
     if args.load_quant:  # directly load quantized weights
         print("Loading pre-computed quantized weights...")

--- a/awq/quantize/pre_quant.py
+++ b/awq/quantize/pre_quant.py
@@ -135,6 +135,9 @@ def run_awq(
         # now solve for scaling and clipping
         input_feat = {k: torch.cat(v, dim=0) for k, v in input_feat.items()}
 
+        # Clear GPU memory
+        torch.cuda.empty_cache()
+
         if auto_scale:  # if it applies, we should also modify the input_feat with scales
             scales_list = auto_scale_block(
                 layer, layer_kwargs,
@@ -145,6 +148,9 @@ def run_awq(
             apply_scale(layers[i], scales_list, input_feat_dict=input_feat)
             # append prefix to make names global
             awq_results["scale"] += append_str_prefix(scales_list, get_op_name(model, layer) + ".")
+
+        # Clear GPU memory
+        torch.cuda.empty_cache()
         
         if mse_range:
             clip_list = auto_clip_block(layer,


### PR DESCRIPTION
Hi @Sakits,

I have added `torch.cuda.empty_cache()` in a couple of places. This was the only way I could quantize 13B parameter models on a 12GB VRAM (RTX 3060).

I think there may be opportunities to lower the memory usage. You may want to hunt down which tensors linger on CUDA longer than necessary and aggressively remove them once they are no longer needed.

For now, the `torch.cuda.empty_cache()` statements I have added lowers the memory footprint just enough.