### PR TITLE
[dev/more_models] Memory optimizations

### DIFF
--- a/awq/quantize/pre_quant.py
+++ b/awq/quantize/pre_quant.py
@@ -95,6 +95,7 @@ def run_awq(
         model(samples.to(next(model.parameters()).device))
     except ValueError:  # work with early exit
         pass
+    del samples
     layers[0] = layers[0].module  # restore
     inps = inps[0]
 

--- a/awq/quantize/qmodule.py
+++ b/awq/quantize/qmodule.py
@@ -93,3 +93,7 @@ class WQLinear(nn.Module):
         out = out + self.bias if self.bias is not None else out
         return out.reshape(out_shape)
     
+    def extra_repr(self) -> str:
+        return 'in_features={}, out_features={}, bias={}, w_bit={}, group_size={}'.format(
+            self.in_features, self.out_features, self.bias is not None, self.w_bit, self.group_size
+        )

--- a/awq/quantize/quantizer.py
+++ b/awq/quantize/quantizer.py
@@ -130,6 +130,7 @@ def real_quantize_model_weight(
                 q_linear = WQLinear.from_linear(
                     module, w_bit, q_config['q_group_size'], False, scales, zeros)
                 module.cpu()
+            q_linear.to(next(layer.parameters()).device)
             set_op_by_name(layer, name, q_linear)
             torch.cuda.empty_cache()
             gc.collect()

--- a/awq/utils/utils.py
+++ b/awq/utils/utils.py
@@ -1,0 +1,43 @@
+import torch
+import accelerate
+
+
+def get_module_by_name_suffix(model, module_name: str):
+    for name, module in model.named_modules():
+        if name.endswith(module_name):
+            return module
+
+def simple_dispatch_model(model, device_map):
+    from accelerate.hooks import add_hook_to_module, AlignDevicesHook
+
+    if "" in device_map:
+        d = device_map[""]
+        model = model.to(torch.device(d))
+        model.hf_device_map = device_map
+        return model
+
+    tied_params = accelerate.utils.modeling.find_tied_parameters(model)
+    if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {"cpu", "disk"}:
+        main_device = "cpu"
+    else:
+        main_device = [d for d in device_map.values() if d not in ["cpu", "disk"]][0]
+
+    cpu_offload_group = [(n, d) for n, d in device_map.items() if d == "cpu"]
+    prev_hook = None
+    for idx, (n, d) in enumerate(cpu_offload_group):
+        m = get_module_by_name_suffix(model, n)
+        _, prev_hook = accelerate.cpu_offload_with_hook(m, execution_device=main_device, prev_module_hook=prev_hook)
+    # set first cpu offload module's prev_module_hook to the last cpu offload module's hook
+    if len(cpu_offload_group) > 1:
+        get_module_by_name_suffix(model, cpu_offload_group[0][0])._hf_hook.prev_module_hook = prev_hook
+
+    for n, d in device_map.items():
+        m = get_module_by_name_suffix(model, n)
+        if d != "cpu":
+            d = torch.device(d)
+            hook = AlignDevicesHook(d, io_same_device=True, place_submodules=True)
+            add_hook_to_module(m, hook)
+    accelerate.utils.modeling.retie_parameters(model, tied_params)
+    model.hf_device_map = device_map
+
+    return model


### PR DESCRIPTION
Hey @Sakits,

I have added the following changes:

1. In `entry.py`, in `init_empty_weights` context block, replaced `from_pretrained` with `from_config` as `from_config` does not load weights, whereas `from_pretrained` does (even inside the `init_empty_weights` context block).

2. Changed how the model is loaded from a checkpoint and is dispatched to GPU/CPU devices. The problem I was facing was with non-persistent buffers such as [rotary embedding buffers](https://huggingface.co/tiiuae/falcon-7b-instruct/blob/main/modeling_falcon.py#L77) that are not stored in the `state_dict` (since they are non-persistent) and they remained on the `meta` device. I had to take inspiration from [AutoGPTQ repo](https://github.com/PanQiWei/AutoGPTQ/blob/c2c5a74f4bc3c4cbd5124fd27dddba751a45b870/auto_gptq/modeling/_utils.py#L152) and have copied the method verbatim.

3. Falcon 7B and 40B have slightly different architectures, so added changes regarding those.

4. While instantiating `WQLinear`, parameters are placed on the CPU whereas buffers (zero-point quantization scales and zero points) are placed on CUDA. This was causing CUDA OOM error as buffers were getting accumulated in CUDA memory layer after layer as quantization progressed.

With these changes and by specifying appropriate `--max_memory` argument, I was able to quantize and evaluate models such as `tiiuae/falcon-40b-instruct` and `mosaicml/mpt-30b-instruct` on RTX 3060 with 12GB VRAM. With reduced `n_samples` (`64` instead of `128`), I was able to quantize `falcon/tiiuae-40b-instruct` on the same GPU.

Thanks!