### PR TITLE
[Minor] Automatically adjust the decoding function based on model settings and user input

### DIFF
--- a/tinychat/benchmark.py
+++ b/tinychat/benchmark.py
@@ -42,7 +42,7 @@ def main():
     parser.add_argument(
         "--max_seq_len",
         type=int,
-        default=2048,
+        default=8192,
         help="maximum sequence length for kv cache",
     )
     parser.add_argument(

--- a/tinychat/demo.py
+++ b/tinychat/demo.py
@@ -84,7 +84,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model_type", type=str, default="LLaMa", help="type of the model"
     )
-    parser.add_argument("--dtype", type=str, default="float16", choices=["float16", "bfloat16"])
+    parser.add_argument(
+        "--dtype", type=str, default="float16", choices=["float16", "bfloat16"]
+    )
     parser.add_argument(
         "--model_path",
         type=str,
@@ -152,7 +154,12 @@ if __name__ == "__main__":
         print("=" * 80)
     # TODO (Haotian): a more elegant implementation here.
     # We need to update these global variables before models use them.
-    from tinychat.models import FalconForCausalLM, LlamaForCausalLM, MPTForCausalLM, Qwen2ForCausalLM
+    from tinychat.models import (
+        FalconForCausalLM,
+        LlamaForCausalLM,
+        MPTForCausalLM,
+        Qwen2ForCausalLM,
+    )
 
     def skip(*args, **kwargs):
         pass
@@ -180,7 +187,7 @@ if __name__ == "__main__":
         "llama": LlamaForCausalLM,
         "falcon": FalconForCausalLM,
         "mpt": MPTForCausalLM,
-        "qwen": Qwen2ForCausalLM
+        "qwen": Qwen2ForCausalLM,
     }
 
     if args.precision == "W4A16":
@@ -206,7 +213,11 @@ if __name__ == "__main__":
             torch_dtype=torch_dtype,
             trust_remote_code=True,
         )
-        model = model_type_dict[args.model_type.lower()](config).to(torch_dtype).to(args.device)
+        model = (
+            model_type_dict[args.model_type.lower()](config)
+            .to(torch_dtype)
+            .to(args.device)
+        )
         model.load_state_dict(loaded_model.state_dict())
     # device warm up
     device_warmup(args.device)
@@ -218,7 +229,9 @@ if __name__ == "__main__":
     stream_generator = StreamGenerator
 
     # Optimize AWQ quantized model
-    if args.precision == "W4A16" and (args.model_type.lower() == "llama" or args.model_type.lower() == "qwen"):
+    if args.precision == "W4A16" and (
+        args.model_type.lower() == "llama" or args.model_type.lower() == "qwen"
+    ):
         from tinychat.modules import make_quant_norm, make_quant_attn
 
         if args.flash_attn:

--- a/tinychat/models/llama.py
+++ b/tinychat/models/llama.py
@@ -102,9 +102,7 @@ class LlamaAttentionFused(nn.Module):
             self.rope_scaling = 1.0
         else:
             self.rope_scaling = 1.0 / self.rope_scaling["factor"]
-
-        # kv_max_seq_len = min(max_seq_len, self.max_position_embeddings)
-        kv_max_seq_len = 8192
+        self.kv_max_seq_len = min(max_seq_len, self.max_position_embeddings)
         self.q_proj = nn.Linear(
             self.hidden_size,
             self.num_heads * self.head_dim,
@@ -133,7 +131,7 @@ class LlamaAttentionFused(nn.Module):
                     max_batch_size,
                     self.num_key_value_heads,
                     # args.max_position_embeddings,
-                    kv_max_seq_len,
+                    self.kv_max_seq_len,
                     self.head_dim,
                 )
             )
@@ -148,7 +146,7 @@ class LlamaAttentionFused(nn.Module):
                     self.num_key_value_heads,
                     self.head_dim // 8,
                     # args.max_position_embeddings,
-                    kv_max_seq_len,
+                    self.kv_max_seq_len,
                     8,
                 )
             )

--- a/tinychat/models/qwen2.py
+++ b/tinychat/models/qwen2.py
@@ -22,6 +22,7 @@ from flash_attn import flash_attn_func
 max_batch_size = tinychat.utils.constants.max_batch_size
 max_seq_len = tinychat.utils.constants.max_seq_len
 
+
 class Qwen2RMSNorm(nn.Module):
     def __init__(self, dim: int, eps: float = 1e-6):
         super().__init__()
@@ -447,7 +448,7 @@ class Qwen2ForCausalLM(Qwen2ForCausalLM):
         self.vocab_size = config.vocab_size
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
         self.config = config
-    
+
     @torch.inference_mode()
     def forward(
         self,
@@ -480,7 +481,7 @@ class Qwen2ForCausalLM(Qwen2ForCausalLM):
         for i in range(10):
             torch.cuda.synchronize()
             tst = time.time()
-            token = self.forward(None, start_pos, inputs_embeds,quant=quant_llm)
+            token = self.forward(None, start_pos, inputs_embeds, quant=quant_llm)
             torch.cuda.synchronize()
             ted = time.time()
         print(

--- a/tinychat/modules/fused_attn.py
+++ b/tinychat/modules/fused_attn.py
@@ -167,7 +167,7 @@ class QuantLlamaAttention(nn.Module):
 
 
 class QuantLlamaAttentionFused(nn.Module):
-    def __init__(self, hidden_size, num_heads, qkv_layer, o_proj, dev, args):
+    def __init__(self, hidden_size, num_heads, kv_max_seq_len, qkv_layer, o_proj, dev, args):
         super().__init__()
 
         self.args = args
@@ -187,7 +187,7 @@ class QuantLlamaAttentionFused(nn.Module):
         self.qkv_proj = qkv_layer
         self.o_proj = o_proj
 
-        kv_max_seq_len = min(max_seq_len, args.max_position_embeddings)
+        self.kv_max_seq_len = kv_max_seq_len
 
         # following fastertransformer definition
         self.cache_v = (
@@ -196,7 +196,7 @@ class QuantLlamaAttentionFused(nn.Module):
                     max_batch_size,
                     self.num_key_value_heads,
                     # args.max_position_embeddings,
-                    kv_max_seq_len,
+                    self.kv_max_seq_len,
                     self.head_dim,
                 )
             )
@@ -211,7 +211,7 @@ class QuantLlamaAttentionFused(nn.Module):
                     self.num_key_value_heads,
                     self.head_dim // 8,
                     # args.max_position_embeddings,
-                    kv_max_seq_len,
+                    self.kv_max_seq_len,
                     8,
                 )
             )
@@ -325,7 +325,7 @@ class QuantLlamaAttentionFusedFlash(nn.Module):
 
     """This function is faster than the varlen one but only supports single-batch inference"""
 
-    def __init__(self, hidden_size, num_heads, qkv_layer, o_proj, dev, args):
+    def __init__(self, hidden_size, num_heads, kv_max_seq_len, qkv_layer, o_proj, dev, args):
         super().__init__()
 
         self.args = args
@@ -345,46 +345,74 @@ class QuantLlamaAttentionFusedFlash(nn.Module):
         self.qkv_proj = qkv_layer
         self.o_proj = o_proj
 
-        # kv_max_seq_len = min(max_seq_len, args.max_position_embeddings)
-        kv_max_seq_len = 8192
+        self.kv_max_seq_len = kv_max_seq_len
         # following fastertransformer definition
-        self.cache_v = (
-            torch.zeros(
-                (
-                    max_batch_size,
-                    self.num_key_value_heads,
-                    # args.max_position_embeddings,
-                    kv_max_seq_len,
-                    self.head_dim,
+        #For short seqlence, we use fused kernel to accelerate decoding.
+        if self.kv_max_seq_len <= 8192: 
+            self.cache_v = (
+                torch.zeros(
+                    (
+                        max_batch_size,
+                        self.num_key_value_heads,
+                        # args.max_position_embeddings,
+                        self.kv_max_seq_len,
+                        self.head_dim,
+                    )
                 )
-            )
-            .to(dev)
-            .half()
-        )  # added to half
-        # 8: pack 8 fp16 in FT, if fp32 then use 4
-        self.cache_k = (
-            torch.zeros(
-                (
-                    max_batch_size,
-                    self.num_key_value_heads,
-                    self.head_dim // 8,
-                    # args.max_position_embeddings,
-                    kv_max_seq_len,
-                    8,
+                .to(dev)
+                .half()
+            )  # added to half
+            # 8: pack 8 fp16 in FT, if fp32 then use 4
+            self.cache_k = (
+                torch.zeros(
+                    (
+                        max_batch_size,
+                        self.num_key_value_heads,
+                        self.head_dim // 8,
+                        # args.max_position_embeddings,
+                        kv_max_seq_len,
+                        8,
+                    )
                 )
-            )
-            .to(dev)
-            .half()
-        )  # added to half
-
-    def forward(
+                .to(dev)
+                .half()
+            )  # added to half
+            self.forward=self.short_forward
+        #For long sequence, we use flash attantion for both prefilling and decoding to avoid OOM.
+        else:
+            self.cache_v = (
+                torch.zeros(
+                    (
+                        max_batch_size,
+                        self.kv_max_seq_len,
+                        self.num_key_value_heads,
+                        self.head_dim,
+                    )
+                )
+                .to(dev)
+                .half()
+            )  # added to half
+            self.cache_k = (
+                torch.zeros(
+                    (
+                        max_batch_size,
+                        self.kv_max_seq_len,
+                        self.num_key_value_heads,
+                        self.head_dim,
+                    )
+                )
+                .to(dev)
+                .half()
+            )  # added to half
+            self.forward=self.long_forward
+    def short_forward(
         self,
         x: torch.Tensor,
         start_pos: int,
         freqs: torch.Tensor,
         mask: Optional[torch.Tensor],
         chunk_prefilling: bool = False,
-    ):
+    ):  
         bsz, seqlen, _ = x.shape
         xqkv = self.qkv_proj(x)
         xqkv = xqkv.view(
@@ -466,8 +494,50 @@ class QuantLlamaAttentionFusedFlash(nn.Module):
             output = output.reshape(bsz, 1, -1)
         return self.o_proj(output)
 
+    def long_forward(
+        self,
+        x: torch.Tensor,
+        start_pos: int,
+        freqs: torch.Tensor,
+        mask: Optional[torch.Tensor],
+        chunk_prefilling: bool = False,
+    ):
+        bsz, seqlen, _ = x.shape
+        xqkv = self.qkv_proj(x)
+        xqkv = xqkv.view(
+            bsz,
+            seqlen,
+            self.n_local_heads + self.num_key_value_heads * 2,
+            self.head_dim,
+        )
+        xq = xqkv[:, :, 0 : self.n_local_heads]
+        xk = xqkv[
+            :, :, self.n_local_heads : (self.n_local_heads + self.num_key_value_heads)
+        ]
+        xv = xqkv[:, :, -self.num_key_value_heads :]
 
-def make_quant_attn(model, dev, flash_attn=0):
+        xq = awq_inference_engine.fused_rope_with_pos_forward_func(xq, freqs, True)
+        xk = awq_inference_engine.fused_rope_with_pos_forward_func(xk, freqs, True)
+
+        self.cache_k = self.cache_k.to(xq)
+        self.cache_v = self.cache_v.to(xq)
+
+        self.cache_v[:bsz, start_pos : start_pos + seqlen] = xv
+        self.cache_k[:bsz, start_pos : start_pos + seqlen] = xk
+        
+        keys = self.cache_k[:, 0 : start_pos + seqlen]
+        values = self.cache_v[:, 0 : start_pos + seqlen]
+            
+
+        output = flash_attn_func(
+            q=xq,
+            k=keys,
+            v=values,
+            causal=True,
+        )
+        output = output.view(bsz, seqlen, -1)
+        return self.o_proj(output)
+def make_quant_attn(model, dev, flash_attn = True):
     """
     Replace all LlamaAttention modules with QuantLlamaAttention modules, fusing the q, k, v projections.
     """
@@ -523,6 +593,7 @@ def make_quant_attn(model, dev, flash_attn=0):
                 attn = QuantLlamaAttentionFusedFlash(
                     m.args.hidden_size,
                     m.args.num_attention_heads,
+                    m.kv_max_seq_len,
                     qkv_layer,
                     m.o_proj,
                     dev,
@@ -532,6 +603,7 @@ def make_quant_attn(model, dev, flash_attn=0):
                 attn = QuantLlamaAttentionFused(
                     m.args.hidden_size,
                     m.args.num_attention_heads,
+                    m.kv_max_seq_len,
                     qkv_layer,
                     m.o_proj,
                     dev,

--- a/tinychat/nvila_benchmark.py
+++ b/tinychat/nvila_benchmark.py
@@ -12,7 +12,6 @@ from transformers import AutoConfig
 import tinychat
 
 
-
 def skip(*args, **kwargs):
     pass
 
@@ -74,6 +73,7 @@ def main() -> None:
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     import tinychat.utils.constants
+
     tinychat.utils.constants.max_seq_len = args.max_seq_len
     from transformers import modeling_utils
 
@@ -93,6 +93,7 @@ def main() -> None:
             make_fused_mlp,
             make_fused_vision_attn,
         )
+
         real_quantize_model_weight(
             model.llm,
             w_bit=4,

--- a/tinychat/nvila_benchmark.py
+++ b/tinychat/nvila_benchmark.py
@@ -9,12 +9,8 @@ import torch
 from awq.quantize import fake_quant
 from awq.quantize.quantizer import real_quantize_model_weight
 from transformers import AutoConfig
-from tinychat.modules import (
-    make_quant_norm,
-    make_quant_attn,
-    make_fused_mlp,
-    make_fused_vision_attn,
-)
+import tinychat
+
 
 
 def skip(*args, **kwargs):
@@ -70,12 +66,15 @@ def main() -> None:
         "--video_path", type=str, default="../figures/nvila_demo_video.mp4"
     )
     parser.add_argument("--image_path", type=str, default="../figures/vila-logo.jpg")
+    parser.add_argument("--max_seq_len", type=int, default=8192)
     args = parser.parse_args()
 
     torch.nn.init.kaiming_uniform_ = skip
     torch.nn.init.kaiming_normal_ = skip
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
+    import tinychat.utils.constants
+    tinychat.utils.constants.max_seq_len = args.max_seq_len
     from transformers import modeling_utils
 
     modeling_utils._init_weights = False
@@ -88,6 +87,12 @@ def main() -> None:
     model = NVILAQwen2(config).half()
     model.llm = model.llm.eval()
     if args.quant_llm or args.all:
+        from tinychat.modules import (
+            make_quant_norm,
+            make_quant_attn,
+            make_fused_mlp,
+            make_fused_vision_attn,
+        )
         real_quantize_model_weight(
             model.llm,
             w_bit=4,

--- a/tinychat/nvila_demo.py
+++ b/tinychat/nvila_demo.py
@@ -48,12 +48,12 @@ def main(args):
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
     tinychat.utils.constants.max_seq_len = args.max_seq_len
-    
+
     # Prepare model
     from tinychat.models.nvila_qwen2 import NVILAQwen2
     from transformers import AutoConfig
     from tinychat.models.qwen2 import Qwen2ForCausalLM
-    
+
     config = AutoConfig.from_pretrained(args.model_path)
     config.resume_path = args.model_path
     if args.quant_llm or args.all:
@@ -73,6 +73,7 @@ def main(args):
             make_fused_mlp,
             make_fused_vision_attn,
         )
+
         model.llm = Qwen2ForCausalLM(model.llm_cfg).half()
         model.llm = load_awq_model(model.llm, args.quant_path, 4, 128, args.device)
         make_quant_attn(model.llm, args.device, True)

--- a/tinychat/nvila_demo.py
+++ b/tinychat/nvila_demo.py
@@ -7,16 +7,8 @@ from llava import conversation as clib
 from llava.media import Image, Video
 import torch
 from awq.quantize import fake_quant
-from tinychat.models.nvila_qwen2 import NVILAQwen2
 from transformers import AutoConfig
-from tinychat.models.qwen2 import Qwen2ForCausalLM
 from tinychat.utils.load_quant import load_awq_model
-from tinychat.modules import (
-    make_quant_norm,
-    make_quant_attn,
-    make_fused_mlp,
-    make_fused_vision_attn,
-)
 from tinychat.utils.llava_image_processing import (
     load_images,
     vis_images,
@@ -55,8 +47,13 @@ def main(args):
     torch.nn.init.kaiming_normal_ = skip
     torch.nn.init.uniform_ = skip
     torch.nn.init.normal_ = skip
-
+    tinychat.utils.constants.max_seq_len = args.max_seq_len
+    
     # Prepare model
+    from tinychat.models.nvila_qwen2 import NVILAQwen2
+    from transformers import AutoConfig
+    from tinychat.models.qwen2 import Qwen2ForCausalLM
+    
     config = AutoConfig.from_pretrained(args.model_path)
     config.resume_path = args.model_path
     if args.quant_llm or args.all:
@@ -70,6 +67,12 @@ def main(args):
         act_scales = torch.load(args.act_scale_path)
         smooth_lm(model.vision_tower, act_scales, 0.3)
     if args.quant_llm or args.all:
+        from tinychat.modules import (
+            make_quant_norm,
+            make_quant_attn,
+            make_fused_mlp,
+            make_fused_vision_attn,
+        )
         model.llm = Qwen2ForCausalLM(model.llm_cfg).half()
         model.llm = load_awq_model(model.llm, args.quant_path, 4, 128, args.device)
         make_quant_attn(model.llm, args.device, True)

--- a/tinychat/stream_generators/NVILA_stream_gen.py
+++ b/tinychat/stream_generators/NVILA_stream_gen.py
@@ -88,8 +88,10 @@ def NVILAStreamGenerator(
         else:
             probs = torch.softmax(last_token_logits.float(), dim=-1)
             if torch.any(torch.isinf(probs)) or torch.any(torch.isnan(probs)):
-                print("[Error] Invalid probabilities detected (Inf/Nan exists). Saving the tensor and exiting...")
-                torch.save(last_token_logits,"last_token_logits.pt")
+                print(
+                    "[Error] Invalid probabilities detected (Inf/Nan exists). Saving the tensor and exiting..."
+                )
+                torch.save(last_token_logits, "last_token_logits.pt")
                 exit()
             token = int(torch.multinomial(probs, num_samples=1))
         output_ids.append(token)

--- a/tinychat/stream_generators/NVILA_stream_gen.py
+++ b/tinychat/stream_generators/NVILA_stream_gen.py
@@ -87,8 +87,9 @@ def NVILAStreamGenerator(
             token = int(torch.argmax(last_token_logits))
         else:
             probs = torch.softmax(last_token_logits.float(), dim=-1)
-            if torch.any(torch.isinf(probs)):
-                print("Error: Invalid probabilities detected (Inf exists). Exiting...")
+            if torch.any(torch.isinf(probs)) or torch.any(torch.isnan(probs)):
+                print("[Error] Invalid probabilities detected (Inf/Nan exists). Saving the tensor and exiting...")
+                torch.save(last_token_logits,"last_token_logits.pt")
                 exit()
             token = int(torch.multinomial(probs, num_samples=1))
         output_ids.append(token)

--- a/tinychat/stream_generators/stream_gen.py
+++ b/tinychat/stream_generators/stream_gen.py
@@ -96,7 +96,10 @@ def StreamGenerator(
                 logits = out.logits
                 past_key_values = out.past_key_values
         else:
-            if ("llama" in model.__class__.__name__.lower() or "qwen" in model.__class__.__name__.lower()) and not quant_llm:
+            if (
+                "llama" in model.__class__.__name__.lower()
+                or "qwen" in model.__class__.__name__.lower()
+            ) and not quant_llm:
                 out = model(
                     inputs,
                     start_pos=start_pos,

--- a/tinychat/utils/input_metadata.py
+++ b/tinychat/utils/input_metadata.py
@@ -92,7 +92,7 @@ class ActivationBuffer:
             (batched_seq_len), device=self.device, dtype=torch.float16
         )
 
-        #For faster act-quant implementation
+        # For faster act-quant implementation
         self.tmp = torch.empty(
             (batched_seq_len * self.intermediate_size),
             device=self.device,

--- a/tinychat/utils/load_quant.py
+++ b/tinychat/utils/load_quant.py
@@ -112,7 +112,7 @@ def make_quant_linear(module, names, w_bit, groupsize, device, name=""):
                     tmp.out_features,
                     tmp.bias is not None,
                     device,
-                    dtype=tmp.weight.dtype
+                    dtype=tmp.weight.dtype,
                 ),
             )
     for name1, child in module.named_children():

--- a/tinychat/utils/prompt_templates.py
+++ b/tinychat/utils/prompt_templates.py
@@ -210,6 +210,7 @@ class Llama3Prompter(BasePrompter):
             system_inst, role1, role2, sen_spliter, qa_spliter, colon=colon
         )
 
+
 class QwenPrompter(BasePrompter):
     def __init__(self):
         system_inst = "<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n"
@@ -221,6 +222,7 @@ class QwenPrompter(BasePrompter):
         super().__init__(
             system_inst, role1, role2, sen_spliter, qa_spliter, colon=colon
         )
+
 
 class LlavaLlamaPrompter(BasePrompter):
     def __init__(self):
@@ -348,7 +350,7 @@ def get_prompter(model_type, model_path="", short_prompt=False, empty_prompt=Fal
         # return FalconPrompter()
         return FalconSimplePrompter()
     elif "qwen" in model_path.lower():
-            return QwenPrompter()
+        return QwenPrompter()
     elif model_type.lower() == "mpt":
         if "mpt" and "chat" in model_path.lower():
             return MPTChatPrompter()


### PR DESCRIPTION
I've refactored the fused attention implementation to dynamically adapt the decoding function according to both model configurations and user input. The system now automatically switches to flash attention for decoding when the maximum sequence length exceeds 8192, while maintaining single query attention for shorter sequences.

Additionally, I've:

Updated the demo and benchmark files to ensure proper functionality with tinychat.utils.constants

Applied code formatting using Black for improved readability and consistency