### PR TITLE
added support for batch eval of llama

### DIFF
--- a/tinychat/demo.py
+++ b/tinychat/demo.py
@@ -240,7 +240,7 @@ if __name__ == "__main__":
             make_quant_attn(model, args.device)
         make_quant_norm(model)
     model(
-        torch.randint(0, 1000, (1, 4096), dtype=torch.int, device="cuda:0"),
+        torch.randint(0, 1000, (1, 2048), dtype=torch.int, device="cuda:0"),
         0,
         quant=args.precision == "W4A16",
     )

--- a/tinychat/models/llama.py
+++ b/tinychat/models/llama.py
@@ -124,6 +124,8 @@ class LlamaAttentionFused(nn.Module):
             bias=False,
         )
 
+        max_batch_size = tinychat.utils.constants.max_batch_size
+
         # following fastertransformer definition
         self.cache_v = (
             torch.zeros(

--- a/tinychat/modules/fused_attn.py
+++ b/tinychat/modules/fused_attn.py
@@ -190,6 +190,7 @@ class QuantLlamaAttentionFused(nn.Module):
         self.o_proj = o_proj
 
         self.kv_max_seq_len = kv_max_seq_len
+        max_batch_size = tinychat.utils.constants.max_batch_size
 
         # following fastertransformer definition
         self.cache_v = (
@@ -350,6 +351,7 @@ class QuantLlamaAttentionFusedFlash(nn.Module):
         self.o_proj = o_proj
 
         self.kv_max_seq_len = kv_max_seq_len
+        max_batch_size = tinychat.utils.constants.max_batch_size
         # following fastertransformer definition
         # For short seqlence, we use fused kernel to accelerate decoding.
         if self.kv_max_seq_len <= 8192:


### PR DESCRIPTION
Added support for benchmarking Llama models with batch_size > 1. To use, append argument `--batch_size n` to the eval command.