### PR TITLE
fix(fused_mlp): drop extra -8*scales on gemm zero-point arg

### DIFF
--- a/tinychat/modules/fused_mlp.py
+++ b/tinychat/modules/fused_mlp.py
@@ -66,14 +66,14 @@ class QuantLlamaMLP(nn.Module):
                 x,
                 self.gate_proj_qweight,
                 self.gate_proj_scales,
-                self.gate_proj_scaled_zeros - 8 * self.gate_proj_scales,
+                self.gate_proj_scaled_zeros,
                 # self.gate_cuda_semaphores
             )
             up_output = awq_inference_engine.gemm_forward_cuda_new(
                 x,
                 self.up_proj_qweight,
                 self.up_proj_scales,
-                self.up_proj_scaled_zeros - 8 * self.up_proj_scales,
+                self.up_proj_scaled_zeros,
                 # self.up_cuda_semaphores
             )
             gate_output = F.silu(gate_output)


### PR DESCRIPTION
#### What does this implement/fix?

`QuantLlamaMLP.our_llama_mlp` passes `scaled_zeros - 8 * scales` to `gemm_forward_cuda_new` on the prefill path (`x.numel() // x.shape[-1] >= 8`), but the gemv path and `WQLinear.forward` both pass `scaled_zeros` unchanged.

The AWQ gemm kernel dequantizes as `raw * scale + zero`, where `scaled_zeros` is already `-zero_point * scale`. Subtracting another `8 * scales` shifts every weight by `-8 * scale` per channel, so prefill MLP outputs are systematically wrong.

#### Root cause

Leftover from an old unsigned int4 mapping; `WQLinear` removed this shift (see comment in `qmodule.py`) but `fused_mlp.py` gemm calls did not.

Made with [Cursor](https://cursor.com)