### PR TITLE
fix(llama): use LlamaConfig for LlamaRotaryEmbedding on transformers 4.48+

### DIFF
--- a/tinychat/models/llama.py
+++ b/tinychat/models/llama.py
@@ -9,6 +9,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 import awq_inference_engine
+from transformers import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 
 # from flash_attn.flash_attn_interface import flash_attn_unpadded_func
@@ -153,10 +154,9 @@ class LlamaAttentionFused(nn.Module):
             .cuda()
             .half()
         )  # added to half
-        # dummy
-        self.rotary_emb = LlamaRotaryEmbedding(
-            self.head_dim, max_position_embeddings=2048, device="cuda:0"
-        )
+        # dummy (LlamaConfig required for transformers >= 4.48)
+        rotary_cfg = LlamaConfig(head_dim=self.head_dim, max_position_embeddings=2048)
+        self.rotary_emb = LlamaRotaryEmbedding(rotary_cfg, device="cuda:0")
 
     def forward(
         self,


### PR DESCRIPTION
## Summary

Fixes TinyChat initialization failure on transformers 4.48+ caused by a breaking change in `LlamaRotaryEmbedding`.

In transformers 4.48, `LlamaRotaryEmbedding` no longer accepts `head_dim` and `max_position_embeddings` as direct keyword arguments. Instead, it expects a `LlamaConfig` object. TinyChat's `LlamaAttentionFused` was still using the old API, which raised an error during model init.

This PR constructs a minimal `LlamaConfig` with the required fields and passes it to `LlamaRotaryEmbedding`, restoring compatibility with transformers 4.48+.

Fixes #269

## Test plan

- [ ] Install transformers >= 4.48
- [ ] Run TinyChat Llama demo / load a Llama AWQ model without init errors
- [ ] Confirm `LlamaAttentionFused` initializes and rotary embeddings work as before
- [ ] Verify behavior on transformers < 4.48 if applicable

Made with [Cursor](https://cursor.com)