### PR TITLE
fix: default rope_theta when missing from HF config

### DIFF
--- a/tinychat/models/falcon.py
+++ b/tinychat/models/falcon.py
@@ -124,12 +124,12 @@ class FalconAttentionFused(nn.Module):
         )  # added to half
 
         self.rotary_emb = RotaryEmbedding(self.head_dim)
-        self.rope_theta = args.rope_theta
+        self.rope_theta = getattr(args, "rope_theta", 10000.0)
         self.rope_scaling = args.rope_scaling
         if self.rope_scaling is None:
             self.rope_scaling = 1.0
         else:
-            self.rope_scaling = 1.0 / self.rope_scaling["factor"]
+            self.rope_scaling = 1.0 / self.rope_scaling.get("factor", 1.0)
 
     def forward(
         self,

--- a/tinychat/models/llama.py
+++ b/tinychat/models/llama.py
@@ -96,12 +96,13 @@ class LlamaAttentionFused(nn.Module):
         self.num_key_value_heads = args.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.max_position_embeddings = args.max_position_embeddings
-        self.rope_theta = args.rope_theta
+        # Older HF Llama configs omit rope_theta (default 10000).
+        self.rope_theta = getattr(args, "rope_theta", 10000.0)
         self.rope_scaling = args.rope_scaling
         if self.rope_scaling is None:
             self.rope_scaling = 1.0
         else:
-            self.rope_scaling = 1.0 / self.rope_scaling["factor"]
+            self.rope_scaling = 1.0 / self.rope_scaling.get("factor", 1.0)
         self.kv_max_seq_len = min(max_seq_len, self.max_position_embeddings)
         self.q_proj = nn.Linear(
             self.hidden_size,
@@ -304,21 +305,22 @@ class Transformer(nn.Module):
         self.norm = RMSNorm(params.hidden_size, eps=params.rms_norm_eps)
 
         # Note (Haotian): rope_theta has to be defined here, otherwise context stage is wrong.
+        rope_theta = getattr(self.params, "rope_theta", 10000.0)
         rope_scale = self.params.rope_scaling
         if rope_scale is None:
             rope_scale = 1.0
         else:
-            rope_scale = 1.0 / rope_scale["factor"]
+            rope_scale = 1.0 / rope_scale.get("factor", 1.0)
         self.freqs = precompute_freqs(
             self.params.hidden_size // self.params.num_attention_heads,
             self.params.max_position_embeddings * 2,
-            self.params.rope_theta,
+            rope_theta,
             rope_scale,
         )
         self.freqs_cis = precompute_freqs_cis(
             self.params.hidden_size // self.params.num_attention_heads,
             self.params.max_position_embeddings * 2,
-            self.params.rope_theta,
+            rope_theta,
             rope_scale,
         )
 

--- a/tinychat/models/qwen2.py
+++ b/tinychat/models/qwen2.py
@@ -340,21 +340,22 @@ class Qwen2Model(nn.Module):
         )
         self.norm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         # Note (Haotian): rope_theta has to be defined here, otherwise context stage is wrong.
+        rope_theta = getattr(config, "rope_theta", 10000.0)
         rope_scale = config.rope_scaling
         if rope_scale is None:
             rope_scale = 1.0
         else:
-            rope_scale = 1.0 / rope_scale["factor"]
+            rope_scale = 1.0 / rope_scale.get("factor", 1.0)
         self.freqs = precompute_freqs(
             config.hidden_size // config.num_attention_heads,
             config.max_position_embeddings * 2,
-            config.rope_theta,
+            rope_theta,
             rope_scale,
         )
         self.freqs_cis = precompute_freqs_cis(
             config.hidden_size // config.num_attention_heads,
             config.max_position_embeddings * 2,
-            config.rope_theta,
+            rope_theta,
             rope_scale,
         )
 

--- a/tinychat/models/qwen2.py
+++ b/tinychat/models/qwen2.py
@@ -138,7 +138,7 @@ class Qwen2AttentionFused(nn.Module):
         self.num_key_value_heads = config.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.max_position_embeddings = config.max_position_embeddings
-        self.rope_theta = config.rope_theta
+        self.rope_theta = getattr(config, "rope_theta", 10000.0)
         self.is_causal = True
         self.attention_dropout = config.attention_dropout
         self.rope_scaling = config.rope_scaling

--- a/tinychat/modules/fused_attn.py
+++ b/tinychat/modules/fused_attn.py
@@ -181,7 +181,7 @@ class QuantLlamaAttentionFused(nn.Module):
         self.num_key_value_heads = args.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.max_position_embeddings = args.max_position_embeddings
-        self.rope_theta = args.rope_theta
+        self.rope_theta = getattr(args, "rope_theta", 10000.0)
         self.rope_scaling = args.rope_scaling
         if self.rope_scaling is None:
             self.rope_scaling = 1.0
@@ -343,7 +343,7 @@ class QuantLlamaAttentionFusedFlash(nn.Module):
         self.num_key_value_heads = args.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.max_position_embeddings = args.max_position_embeddings
-        self.rope_theta = args.rope_theta
+        self.rope_theta = getattr(args, "rope_theta", 10000.0)
         self.rope_scaling = args.rope_scaling
         if self.rope_scaling is None:
             self.rope_scaling = 1.0


### PR DESCRIPTION
## Summary
- Older Llama configs lack `rope_theta`, causing AttributeError in TinyChat
- Default to 10000; also soft-fail missing rope_scaling factor

Fixes #222

## Test plan
- [ ] Load llama-2 HF config without rope_theta in tinychat demo

Made with [Cursor](https://cursor.com)