### PR TITLE
Accept *args in Catcher.forward for ChatGLM-style models

### DIFF
--- a/awq/quantize/pre_quant.py
+++ b/awq/quantize/pre_quant.py
@@ -139,7 +139,8 @@ def run_awq(
             super().__init__()
             self.module = module
 
-        def forward(self, inp, **kwargs):
+        def forward(self, inp, *args, **kwargs):
+            # Some models (e.g. ChatGLM) pass extra positional args beyond inp.
             inps.append(inp)
             layer_kwargs.update(kwargs)
             raise ValueError  # early exit to break later inference


### PR DESCRIPTION
## Summary
- `Catcher.forward(self, inp, **kwargs)` raises TypeError when models pass extra positional args (#158)
- Accept `*args` and ignore them (only `inp` + kwargs matter for calibration)

## Test plan
- [ ] `run_awq` on a ChatGLM (or similar) model completes past Catcher hook

Fixes #158

Made with [Cursor](https://cursor.com)