### PR TITLE
Fall back to gemm_forward_cuda when _new missing

### DIFF
--- a/awq/quantize/qmodule.py
+++ b/awq/quantize/qmodule.py
@@ -204,7 +204,14 @@ class WQLinear(nn.Module):
         # inputs = x.reshape(-1, x.shape[-1])
         inputs = x
         if inputs.numel() / inputs.shape[-1] < 8:
-            out = awq_inference_engine.gemv_forward_cuda_new(
+            gemv = getattr(
+                awq_inference_engine, "gemv_forward_cuda_new", None
+            ) or getattr(awq_inference_engine, "gemv_forward_cuda", None)
+            if gemv is None:
+                raise AttributeError(
+                    "awq_inference_engine has neither gemv_forward_cuda_new nor gemv_forward_cuda"
+                )
+            out = gemv(
                 inputs,
                 self.qweight,
                 self.scales,
@@ -215,9 +222,21 @@ class WQLinear(nn.Module):
                 self.group_size,
             )
         else:
-            out = awq_inference_engine.gemm_forward_cuda_new(
-                inputs, self.qweight, self.scales, self.scaled_zeros
-            )  # - 8.0 * self.scales)
+            # Prefer new kernel; fall back for older builds (#153).
+            gemm = getattr(
+                awq_inference_engine, "gemm_forward_cuda_new", None
+            )
+            if gemm is not None:
+                out = gemm(inputs, self.qweight, self.scales, self.scaled_zeros)
+            else:
+                out = awq_inference_engine.gemm_forward_cuda(
+                    inputs,
+                    self.qweight,
+                    self.scales,
+                    self.scaled_zeros,
+                    self.group_size,
+                    self.split_k_iters,
+                )
         out = out + self.bias if self.bias is not None else out
         # print(out)
         # assert 0

--- a/tinychat/modules/fused_mlp.py
+++ b/tinychat/modules/fused_mlp.py
@@ -59,22 +59,31 @@ class QuantLlamaMLP(nn.Module):
                 self.down_proj.group_size,
             )
         else:
-            # num_mn_tiles = (x.shape[0] // 32) * (self.intermediate_size // 128)
-            # cuda_Semaphores_gate = torch.empty(num_mn_tiles).int().to(x.device)
-            # cuda_Semaphores_up = torch.empty(num_mn_tiles).int().to(x.device)
-            gate_output = awq_inference_engine.gemm_forward_cuda_new(
+            # Prefer new kernel; fall back for older builds (#153).
+            def _gemm(x, qw, scales, zeros):
+                gemm = getattr(awq_inference_engine, "gemm_forward_cuda_new", None)
+                if gemm is not None:
+                    return gemm(x, qw, scales, zeros)
+                return awq_inference_engine.gemm_forward_cuda(
+                    x,
+                    qw,
+                    scales,
+                    zeros,
+                    self.down_proj.group_size,
+                    getattr(self.down_proj, "split_k_iters", 8),
+                )
+
+            gate_output = _gemm(
                 x,
                 self.gate_proj_qweight,
                 self.gate_proj_scales,
                 self.gate_proj_scaled_zeros - 8 * self.gate_proj_scales,
-                # self.gate_cuda_semaphores
             )
-            up_output = awq_inference_engine.gemm_forward_cuda_new(
+            up_output = _gemm(
                 x,
                 self.up_proj_qweight,
                 self.up_proj_scales,
                 self.up_proj_scaled_zeros - 8 * self.up_proj_scales,
-                # self.up_cuda_semaphores
             )
             gate_output = F.silu(gate_output)
 


### PR DESCRIPTION
## Summary
- Older engines lack `gemm_forward_cuda_new` (#153)
- `WQLinear` / fused MLP fall back to `gemm_forward_cuda`

## Test plan
- [ ] Load W4A16 with older kernel build; no AttributeError

Fixes #153

Made with [Cursor](https://cursor.com)