### PR TITLE
Size TinyChat RoPE from config/max_seq_len

### DIFF
--- a/tinychat/models/llama.py
+++ b/tinychat/models/llama.py
@@ -155,7 +155,9 @@ class LlamaAttentionFused(nn.Module):
         )  # added to half
         # dummy
         self.rotary_emb = LlamaRotaryEmbedding(
-            self.head_dim, max_position_embeddings=2048, device="cuda:0"
+            self.head_dim,
+            max_position_embeddings=self.max_position_embeddings,
+            device=dev,
         )
 
     def forward(

--- a/tinychat/modules/fused_attn.py
+++ b/tinychat/modules/fused_attn.py
@@ -96,7 +96,7 @@ class QuantLlamaAttention(nn.Module):
         self.qkv_proj = qkv_proj
         self.o_proj = o_proj
         self.rotary_emb = QuantLlamaRotaryEmbedding(
-            self.head_dim, max_position_embeddings=2048, device=dev
+            self.head_dim, max_position_embeddings=max_seq_len, device=dev
         )
 
     def forward(


### PR DESCRIPTION
## Summary
- RoPE cache hardcoded to 2048; long-context models truncated. Also used `cuda:0` over `dev`.

## Test plan
- [ ] LlamaAttentionFused uses `max_position_embeddings`; QuantLlamaAttention uses `max_seq_len`

Made with [Cursor](https://cursor.com)