### PR TITLE
Fix Qwen2 rope 1/factor and scale_fc_fc bias slice

### DIFF
--- a/awq/quantize/auto_scale.py
+++ b/awq/quantize/auto_scale.py
@@ -62,7 +62,8 @@ def scale_fc_fc(fc1, fc2, scales):
     # fc1.weight.div_(scales.view(-1, 1))
     fc1.weight[-scales.size(0) :].div_(scales.view(-1, 1))
     if fc1.bias is not None:
-        fc1.bias.div_(scales.view(-1))
+        # Match weight slice: only last N bias entries pair with scaled rows.
+        fc1.bias[-scales.size(0) :].div_(scales.view(-1))
 
     fc2.weight.mul_(scales.view(1, -1))
 

--- a/tinychat/models/qwen2.py
+++ b/tinychat/models/qwen2.py
@@ -145,7 +145,8 @@ class Qwen2AttentionFused(nn.Module):
         if self.rope_scaling is None:
             self.rope_scaling = 1.0
         elif isinstance(self.rope_scaling, dict):
-            self.rope_scaling = self.rope_scaling.get("factor", 1.0)
+            # Match Transformer prefills: kernel expects 1/factor.
+            self.rope_scaling = 1.0 / self.rope_scaling.get("factor", 1.0)
 
         if (self.head_dim * self.num_heads) != self.hidden_size:
             raise ValueError(


### PR DESCRIPTION
## Summary
- Qwen2 Attention used raw rope `factor`; prefills used `1/factor`
- `scale_fc_fc` scaled full bias while only last N weight rows are scaled

## Test plan
- [ ] Qwen2 with `rope_scaling.factor` matches prefills on decode
- [ ] `scale_fc_fc` bias length > scales → only tail entries change


Made with [Cursor](https://cursor.com)