### PR TITLE
fix: keep fused attn values on the activation device

### DIFF
--- a/tinychat/modules/fused_attn.py
+++ b/tinychat/modules/fused_attn.py
@@ -138,7 +138,7 @@ class QuantLlamaAttention(nn.Module):
         if past_key_value is not None:
             kv_seq_len += past_key_value[0].shape[-2]
 
-        value_states = value_states.to("cuda:0")
+        value_states = value_states.to(hidden_states.device)
 
         if past_key_value is not None:
             # reuse k, v, self_attention


### PR DESCRIPTION
## Summary
- `value_states.to("cuda:0")` breaks multi-GPU / non-zero device runs.
- Move to `hidden_states.device` instead.

## Test plan
- [ ] Smoke fused Llama attn on `cuda:1` if available


Made with [Cursor](https://cursor.com)