### PR TITLE
fix: avoid KeyError saving wikitext results with --output_path

### DIFF
--- a/awq/entry.py
+++ b/awq/entry.py
@@ -345,12 +345,12 @@ def main():
 
             print(evaluator.make_table(results))
 
-        if args.output_path is not None:
-            os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
-            # otherwise cannot save
-            results["config"]["model"] = args.model_path
-            with open(args.output_path, "w") as f:
-                json.dump(results, f, indent=2)
+            if args.output_path is not None:
+                os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
+                # otherwise cannot save
+                results["config"]["model"] = args.model_path
+                with open(args.output_path, "w") as f:
+                    json.dump(results, f, indent=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Wikitext eval builds `results = {"ppl": ...}` and may write `--output_path` once.
- A shared post-eval save path always did `results["config"]["model"] = ...`, which raises `KeyError: 'config'` for wikitext after a successful run.
- Keep the config-enriching save only on the lm-eval branch (wikitext already saves its own payload).

## Test plan
- [x] Static repro: `results = {"ppl": 1.0}` then `results["config"]["model"]` → KeyError (pre-fix)
- [x] `python3 -m py_compile awq/entry.py`
- [ ] Run `--tasks wikitext --output_path /tmp/awq_ppl.json` and confirm the file is written without traceback
- [ ] Run a non-wikitext lm-eval task with `--output_path` and confirm `config.model` is still injected

Made with [Cursor](https://cursor.com)